### PR TITLE
worker should only log and not change state on an AWS error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Setup
 
-To be able to build and run the project locally a things need to be set first.
+To be able to build and run the project locally a few things need to be set first.
 
-- A `.npmrc` file is needed with the following content:
+- `.npmrc` file is needed with the following content:
 
 ``` txt
 @eyevinn:registry=https://npm.pkg.github.com

--- a/index.ts
+++ b/index.ts
@@ -53,8 +53,7 @@ export class Worker {
       try {
         const collectedMessages: any[] = await this.queue.receive();
         if (!Array.isArray(collectedMessages)) {
-          this.logger.warn(`[${this.workerId}]: Received Error from Queue. Stopping Worker.`);
-          this.state = WorkerState.INACTIVE;
+          this.logger.warn(`[${this.workerId}]: Error collecting messages from queue`);
           continue;
         }
         if (!collectedMessages || collectedMessages.length === 0) {
@@ -70,10 +69,7 @@ export class Worker {
             try {
               await this.db.createTable(tableName);
             } catch (err) {
-              this.logger.error(
-                `[${this.workerId}]: Failed to create table '${tableName}'`,
-                err
-              );
+              this.logger.error(`[${this.workerId}]: Failed to create table '${tableName}'`, err);
             }
           }
           writePromises.push(this.db.write(eventJson, tableName));
@@ -98,10 +94,7 @@ export class Worker {
           }
         });
       } catch (err) {
-        this.logger.error(
-          `[${this.workerId}]: Stopping Worker! Unexpected Error: ${err}`
-        );
-        this.state = WorkerState.INACTIVE;
+        this.logger.error(`[${this.workerId}]: Error: ${err}`);
       }
     }
   }

--- a/lib/EventDB.ts
+++ b/lib/EventDB.ts
@@ -15,10 +15,15 @@ export default class EventDB {
 
   public async TableExists(tableName: string): Promise<boolean> {
     await this.getDBAdapter();
-    // - If cache does not have the requested table name. Update cache, it might be there.
-    if (!this.tableNamesCache.includes(tableName)) {
-      this.logger.info(`[${this.instanceId}]: Updating tableNames cache`);
-      this.tableNamesCache = await this.DBAdapter.getTableNames();
+    try {
+      // - If cache does not have the requested table name. Update cache, it might be there.
+      if (!this.tableNamesCache.includes(tableName)) {
+        this.logger.debug(`[${this.instanceId}]: Updating tableNames cache`);
+        this.tableNamesCache = await this.DBAdapter.getTableNames();
+      }
+    } catch (err) {
+      this.logger.error(`[${this.instanceId}]: Failed to update tableNames cache!`);
+      throw new Error(err);
     }
     return this.tableNamesCache.includes(tableName);
   }
@@ -27,7 +32,7 @@ export default class EventDB {
     try {
       await this.DBAdapter.createTable(name);
     } catch (err) {
-      this.logger.warn(`[${this.instanceId}]: Problem when creating table`);
+      this.logger.error(`[${this.instanceId}]: Failed to create table '${name}'!`);
       throw new Error(err);
     }
   }


### PR DESCRIPTION
Fixes: #8 

This PR updates the logic for a Worker so that we do not change state to `INACTIVE` on an AWS or any other type of services related error. The error is now logged and the Worker will continue. 