### PR TITLE
feat: implement internal memory queue with backpressure and improved error handling

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export { Worker, WorkerState } from './lib/Worker';
+export { default as InternalQueue } from './lib/InternalQueue';

--- a/lib/EventDB.ts
+++ b/lib/EventDB.ts
@@ -1,5 +1,12 @@
 import winston from 'winston';
 import { AbstractDBAdapter } from '@eyevinn/player-analytics-shared/types/interfaces';
+
+interface BatchWriteResult {
+  success: boolean;
+  tableName: string;
+  error?: any;
+}
+
 export default class EventDB {
   logger: winston.Logger;
   DBAdapter: AbstractDBAdapter;
@@ -77,5 +84,29 @@ export default class EventDB {
       this.logger.error(err.message);
       throw err;
     }
+  }
+
+  public async batchWriteByTable(eventsByTable: { [tableName: string]: any[] }): Promise<BatchWriteResult[]> {
+    await this.getDBAdapter();
+    const writePromises: Promise<BatchWriteResult>[] = [];
+
+    for (const [tableName, events] of Object.entries(eventsByTable)) {
+      if (events.length === 0) continue;
+
+      const writePromise = this.writeMultiple(events, tableName)
+        .then(() => ({ success: true, tableName }))
+        .catch((error) => ({ success: false, tableName, error }));
+
+      writePromises.push(writePromise);
+    }
+
+    const results = await Promise.all(writePromises);
+
+    const successCount = results.filter(r => r.success).length;
+    const failureCount = results.length - successCount;
+
+    this.logger.debug(`[${this.instanceId}]: Batch write completed: ${successCount} successes, ${failureCount} failures`);
+
+    return results;
   }
 }

--- a/lib/InternalQueue.ts
+++ b/lib/InternalQueue.ts
@@ -1,0 +1,124 @@
+import winston from 'winston';
+
+interface QueuedMessage {
+  message: any;
+  event: any;
+  tableName: string;
+  messageIndex: number;
+  retryCount: number;
+  addedAt: number;
+}
+
+export default class InternalQueue {
+  private logger: winston.Logger;
+  private instanceId: string;
+  private queue: QueuedMessage[] = [];
+  private batchSize: number;
+  private processingInterval: number;
+  private maxRetries: number;
+  public maxQueueSize: number;
+  private isProcessing: boolean = false;
+
+  constructor(logger: winston.Logger, instanceId: string) {
+    this.logger = logger;
+    this.instanceId = instanceId;
+    this.batchSize = process.env.INTERNAL_QUEUE_BATCH_SIZE ?
+      parseInt(process.env.INTERNAL_QUEUE_BATCH_SIZE) : 50;
+    this.processingInterval = process.env.INTERNAL_QUEUE_INTERVAL ?
+      parseInt(process.env.INTERNAL_QUEUE_INTERVAL) : 1000;
+    this.maxRetries = process.env.INTERNAL_QUEUE_MAX_RETRIES ?
+      parseInt(process.env.INTERNAL_QUEUE_MAX_RETRIES) : 3;
+    this.maxQueueSize = process.env.INTERNAL_QUEUE_MAX_SIZE ?
+      parseInt(process.env.INTERNAL_QUEUE_MAX_SIZE) : 1000;
+  }
+
+  public add(message: any, event: any, tableName: string, messageIndex: number): boolean {
+    if (this.queue.length >= this.maxQueueSize) {
+      this.logger.warn(`[${this.instanceId}]: Internal queue is full (${this.maxQueueSize}). Cannot add message.`);
+      return false;
+    }
+
+    const queuedMessage: QueuedMessage = {
+      message,
+      event,
+      tableName,
+      messageIndex,
+      retryCount: 0,
+      addedAt: Date.now()
+    };
+
+    this.queue.push(queuedMessage);
+    this.logger.debug(`[${this.instanceId}]: Added message to internal queue. Queue size: ${this.queue.length}`);
+    return true;
+  }
+
+  public hasCapacity(count: number = 1): boolean {
+    return (this.queue.length + count) <= this.maxQueueSize;
+  }
+
+  public getAvailableCapacity(): number {
+    return Math.max(0, this.maxQueueSize - this.queue.length);
+  }
+
+  public getQueueSize(): number {
+    return this.queue.length;
+  }
+
+  public getBatch(): QueuedMessage[] {
+    if (this.queue.length === 0) {
+      return [];
+    }
+
+    const batch = this.queue.splice(0, Math.min(this.batchSize, this.queue.length));
+    this.logger.debug(`[${this.instanceId}]: Retrieved batch of ${batch.length} messages. Remaining: ${this.queue.length}`);
+    return batch;
+  }
+
+  public requeue(messages: QueuedMessage[]): void {
+    const requeueableMessages = messages.filter(msg => {
+      if (msg.retryCount >= this.maxRetries) {
+        this.logger.error(`[${this.instanceId}]: Message exceeded max retries (${this.maxRetries}), dropping`);
+        return false;
+      }
+      msg.retryCount++;
+      return true;
+    });
+
+    this.queue.unshift(...requeueableMessages);
+    this.logger.debug(`[${this.instanceId}]: Requeued ${requeueableMessages.length} messages`);
+  }
+
+  public groupByTable(batch: QueuedMessage[]): { [tableName: string]: QueuedMessage[] } {
+    const grouped: { [tableName: string]: QueuedMessage[] } = {};
+
+    for (const queuedMessage of batch) {
+      if (!grouped[queuedMessage.tableName]) {
+        grouped[queuedMessage.tableName] = [];
+      }
+      grouped[queuedMessage.tableName].push(queuedMessage);
+    }
+
+    return grouped;
+  }
+
+  public isEmpty(): boolean {
+    return this.queue.length === 0;
+  }
+
+  public clear(): void {
+    this.queue = [];
+    this.logger.debug(`[${this.instanceId}]: Internal queue cleared`);
+  }
+
+  public getStats(): { size: number, oldestMessage: number | null } {
+    if (this.queue.length === 0) {
+      return { size: 0, oldestMessage: null };
+    }
+
+    const oldestMessage = Math.min(...this.queue.map(msg => msg.addedAt));
+    return {
+      size: this.queue.length,
+      oldestMessage: Date.now() - oldestMessage
+    };
+  }
+}

--- a/lib/Worker.ts
+++ b/lib/Worker.ts
@@ -1,6 +1,7 @@
 import winston from 'winston';
 import EventDB from './EventDB';
 import Queue from './Queue';
+import InternalQueue from './InternalQueue';
 import { TABLE_PREFIX } from '@eyevinn/player-analytics-shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -22,11 +23,17 @@ export class Worker {
   logger: winston.Logger;
   queue: any;
   db: any;
+  internalQueue: InternalQueue;
   state: string;
   workerId: string;
   tablePrefix: string;
   iterations: number;
   maxAge: number;
+  sqsPullInterval: number;
+  dbProcessInterval: number;
+  isPaused: boolean;
+  pauseDuration: number;
+  private pausedAt: number;
 
   constructor(opts: IWorkerOptions) {
     this.logger = opts.logger;
@@ -36,13 +43,42 @@ export class Worker {
     this.state = WorkerState.IDLE;
     this.queue = new Queue(opts.logger, this.workerId);
     this.db = new EventDB(opts.logger, this.workerId);
+    this.internalQueue = new InternalQueue(opts.logger, this.workerId);
     this.maxAge = process.env.MAX_AGE ? parseInt(process.env.MAX_AGE) : 60000;
+    this.sqsPullInterval = process.env.SQS_PULL_INTERVAL ? parseInt(process.env.SQS_PULL_INTERVAL) : 1000;
+    this.dbProcessInterval = process.env.DB_PROCESS_INTERVAL ? parseInt(process.env.DB_PROCESS_INTERVAL) : 2000;
+    this.isPaused = false;
+    this.pausedAt = 0;
+    this.pauseDuration = process.env.PAUSE_DURATION ? parseInt(process.env.PAUSE_DURATION) : 300000; // 5 minutes default
+  }
+
+  resume() {
+    if (this.isPaused) {
+      this.logger.info(`[${this.workerId}]: Resuming worker from paused state`);
+      this.isPaused = false;
+      this.pausedAt = 0;
+    }
+  }
+
+  pause() {
+    if (!this.isPaused) {
+      this.logger.info(`[${this.workerId}]: Pausing worker`);
+      this.isPaused = true;
+      this.pausedAt = Date.now();
+    }
   }
 
   // For unit tests only
   setLoopIterations(iterations: number) {
     this.logger.warn(`[${this.workerId}]: Setting worker iterations to: ${iterations}`);
     this.iterations = iterations;
+  }
+
+  // For unit tests only - set faster intervals for testing
+  setTestIntervals(sqsInterval: number = 100, dbInterval: number = 200) {
+    this.sqsPullInterval = sqsInterval;
+    this.dbProcessInterval = dbInterval;
+    this.logger.warn(`[${this.workerId}]: Test mode - SQS interval: ${sqsInterval}ms, DB interval: ${dbInterval}ms`);
   }
 
   private async removeFromQueue(message: any) {
@@ -54,114 +90,204 @@ export class Worker {
     }
   }
 
+  private async processSQSMessages() {
+    try {
+      // Check if internal queue has capacity before consuming from SQS
+      if (!this.internalQueue.hasCapacity(1)) {
+        this.logger.debug(`[${this.workerId}]: Internal queue is full (${this.internalQueue.getQueueSize()}/${this.internalQueue.maxQueueSize}). Skipping SQS consumption.`);
+        return;
+      }
+
+      const collectedMessages: any[] = await this.queue.receive();
+
+      if (!Array.isArray(collectedMessages) || collectedMessages.length === 0) {
+        this.logger.debug(`[${this.workerId}]: No messages received from SQS`);
+        return;
+      }
+
+      this.logger.debug(`[${this.workerId}]: Retrieved ${collectedMessages.length} messages from SQS`);
+
+      const allEvents: any[] = this.queue.getEventJSONsFromMessages(collectedMessages);
+      const pendingMessages: { message: any, event: any, tableName: string, index: number }[] = [];
+
+      // First pass: validate all messages and check for available tables
+      for (let i = 0; i < allEvents.length; i++) {
+        const eventJson = allEvents[i];
+        const shardId = eventJson.shardId ? eventJson.shardId : (eventJson.host ? eventJson.host : 'default');
+        const tableName: string = this.tablePrefix + shardId;
+
+        const tableExists: boolean = await this.db.TableExists(tableName);
+        if (!tableExists) {
+          this.logger.warn(`[${this.workerId}]: No Table named:'${tableName}' was found`);
+          if (Date.now() - eventJson.timestamp > this.maxAge) {
+            this.logger.warn(`[${this.workerId}]: Event has expired. Removing event from queue`);
+            await this.removeFromQueue(collectedMessages[i]);
+          }
+          continue;
+        }
+
+        pendingMessages.push({
+          message: collectedMessages[i],
+          event: eventJson,
+          tableName,
+          index: i
+        });
+      }
+
+      // Second pass: add messages to internal queue with capacity check
+      let addedCount = 0;
+      let skippedCount = 0;
+
+      for (const pending of pendingMessages) {
+        if (!this.internalQueue.hasCapacity(1)) {
+          skippedCount++;
+          this.logger.warn(`[${this.workerId}]: Internal queue capacity exceeded. Skipping remaining ${pendingMessages.length - addedCount - skippedCount + 1} messages.`);
+          break;
+        }
+
+        const added = this.internalQueue.add(pending.message, pending.event, pending.tableName, pending.index);
+        if (added) {
+          addedCount++;
+        } else {
+          skippedCount++;
+          this.logger.error(`[${this.workerId}]: Failed to add message to internal queue despite capacity check`);
+        }
+      }
+
+      if (skippedCount > 0) {
+        this.logger.warn(`[${this.workerId}]: Could not process ${skippedCount} messages due to internal queue capacity. Messages remain in SQS for retry.`);
+      }
+
+      this.logger.debug(`[${this.workerId}]: Added ${addedCount} messages to internal queue. Queue size: ${this.internalQueue.getQueueSize()}`);
+    } catch (err) {
+      this.logger.error(`[${this.workerId}]: Error processing SQS messages: ${err}`);
+    }
+  }
+
+  private async processInternalQueue() {
+    if (this.internalQueue.isEmpty()) {
+      return;
+    }
+
+    try {
+      const batch = this.internalQueue.getBatch();
+      if (batch.length === 0) {
+        return;
+      }
+
+      this.logger.debug(`[${this.workerId}]: Processing batch of ${batch.length} messages from internal queue`);
+
+      const groupedByTable = this.internalQueue.groupByTable(batch);
+      const eventsByTable: { [tableName: string]: any[] } = {};
+
+      for (const [tableName, queuedMessages] of Object.entries(groupedByTable)) {
+        eventsByTable[tableName] = queuedMessages.map(qm => qm.event);
+      }
+
+      const writeResults = await this.db.batchWriteByTable(eventsByTable);
+
+      const successfulMessages: any[] = [];
+      const failedMessages: any[] = [];
+
+      for (const result of writeResults) {
+        const tableMessages = groupedByTable[result.tableName];
+        if (result.success) {
+          successfulMessages.push(...tableMessages.map(qm => qm.message));
+        } else {
+          this.logger.error(`[${this.workerId}]: Failed to write to table ${result.tableName}:`, result.error);
+          failedMessages.push(...tableMessages);
+        }
+      }
+
+      for (const message of successfulMessages) {
+        await this.removeFromQueue(message);
+      }
+
+      if (failedMessages.length > 0) {
+        this.internalQueue.requeue(failedMessages);
+      }
+
+      this.logger.debug(`[${this.workerId}]: Processed batch: ${successfulMessages.length} successful, ${failedMessages.length} failed`);
+
+    } catch (err) {
+      this.logger.error(`[${this.workerId}]: Error processing internal queue batch: ${err}`);
+    }
+  }
+
   async startAsync() {
     this.state = WorkerState.ACTIVE;
-    this.logger.debug(`[${this.workerId}]: Worker is Active...`);
+    this.logger.info(`[${this.workerId}]: Worker starting with internal queue - SQS pull interval: ${this.sqsPullInterval}ms, DB process interval: ${this.dbProcessInterval}ms`);
 
+    let sqsLastRun = 0;
+    let dbLastRun = 0;
     let failedIterations = 0;
-    let isPaused = false;
+    let errorBackoffMs = 1000;
+    const maxErrorBackoffMs = 20000;
+
     while (this.state === WorkerState.ACTIVE) {
-      if (isPaused) {
-        // This will pause the worker but not terminate the process.
-        // Issue for failed writes needs to be fixed first and then the worker can be
-        // restarted.
-        await delay(30000);
-        continue;
+      if (this.isPaused) {
+        // Check if pause duration has elapsed for auto-resume
+        if (this.pausedAt > 0 && Date.now() - this.pausedAt >= this.pauseDuration) {
+          this.logger.info(`[${this.workerId}]: Auto-resuming worker after ${this.pauseDuration}ms pause`);
+          this.resume();
+        } else {
+          await delay(30000);
+          continue;
+        }
       }
+
       // For Unit tests
       if (this.iterations > 0) this.iterations--;
       if (this.iterations === 0) this.state = WorkerState.INACTIVE;
 
-      this.logger.debug(`[${this.workerId}]: Worker is fetching from Queue...`);
+      const now = Date.now();
+
       try {
-        const collectedMessages: any[] = await this.queue.receive();
-        if (!Array.isArray(collectedMessages)) {
-          this.logger.warn(`[${this.workerId}]: Error collecting messages from queue`);
-          continue;
-        }
-        if (!collectedMessages || collectedMessages.length === 0) {
-          this.logger.debug(`[${this.workerId}]: Received No Messages from Queue. Going to Try Again`);
-          await delay(3000);
-          continue;
-        }
-        const allEvents: any[] = this.queue.getEventJSONsFromMessages(collectedMessages);
-        const validMessages: any[] = [];
-        const eventsByTable: { [tableName: string]: { events: any[], messageIndices: number[] } } = {};
-        
-        for (let i = 0; i < allEvents.length; i++) {
-          const eventJson = allEvents[i];
-          const shardId = eventJson.shardId ? eventJson.shardId : (eventJson.host ? eventJson.host : 'default');
-          const tableName: string = this.tablePrefix + shardId;
-          const result: boolean = await this.db.TableExists(tableName);
-          if (!result) {
-            this.logger.warn(`[${this.workerId}]: No Table named:'${tableName}' was found`);
-            if (Date.now() - eventJson.timestamp > this.maxAge) {
-              this.logger.warn(`[${this.workerId}]: Event has expired. Removing event from queue`);
-              await this.removeFromQueue(collectedMessages[i]);
-            }
-            continue;
-          }
-          validMessages.push(collectedMessages[i]);
-          
-          if (!eventsByTable[tableName]) {
-            eventsByTable[tableName] = { events: [], messageIndices: [] };
-          }
-          eventsByTable[tableName].events.push(eventJson);
-          eventsByTable[tableName].messageIndices.push(validMessages.length - 1);
+        // Process SQS messages at configured interval
+        if (now - sqsLastRun >= this.sqsPullInterval) {
+          await this.processSQSMessages();
+          sqsLastRun = now;
         }
 
-        const writePromises: Promise<any>[] = [];
-        const tableNames: string[] = [];
-        for (const [tableName, tableData] of Object.entries(eventsByTable)) {
-          writePromises.push(this.db.writeMultiple(tableData.events, tableName));
-          tableNames.push(tableName);
+        // Process internal queue at configured interval
+        if (now - dbLastRun >= this.dbProcessInterval) {
+          await this.processInternalQueue();
+          dbLastRun = now;
         }
-        
-        const writeResults = await Promise.allSettled(writePromises);
-        let pushedMessages: any[] = [];
-        let hasFailures = false;
-        
-        for (let i = 0; i < writeResults.length; i++) {
-          const result = writeResults[i];
-          const tableName = tableNames[i];
-          const tableData = eventsByTable[tableName];
-          
-          if (result.status === 'fulfilled') {
-            // Add all messages for this table to pushedMessages
-            for (const msgIndex of tableData.messageIndices) {
-              pushedMessages.push(validMessages[msgIndex]);
-            }
-          } else {
-            hasFailures = true;
-            this.logger.error(`[${this.workerId}]: Failed to write to table ${tableName}:`, result.reason);
+
+        // Brief delay to prevent tight loops
+        await delay(100);
+
+        // Log queue stats periodically
+        if (now % 30000 < 1000) {
+          const stats = this.internalQueue.getStats();
+          const capacity = this.internalQueue.getAvailableCapacity();
+          if (stats.size > 0) {
+            this.logger.info(`[${this.workerId}]: Internal queue stats - Size: ${stats.size}/${this.internalQueue.maxQueueSize}, Available capacity: ${capacity}, Oldest message: ${stats.oldestMessage}ms`);
+          }
+          if (capacity === 0) {
+            this.logger.warn(`[${this.workerId}]: Internal queue is at capacity! SQS consumption is paused.`);
           }
         }
-        if (pushedMessages.length == 0 && validMessages.length > 0) {
-          this.logger.warn(`[${this.workerId}]: No messages were pushed to the database but we have ${validMessages.length} valid messages.`);
-          failedIterations++;
-          if (failedIterations > 5) {
-            this.logger.error(`[${this.workerId}]: Too many failed iterations (${failedIterations}). Pausing worker.`);
-            isPaused = true;
-          }
-        } else {
-          this.logger.debug(`[${this.workerId}]: Successfully pushed ${pushedMessages.length} messages to the database.`);
-          failedIterations = 0;
-          for (let i = 0; i < pushedMessages.length; i++) {
-            await this.removeFromQueue(pushedMessages[i]);
-          }
-          
-          // Check for abort conditions
-          for (const result of writeResults) {
-            if (result.status === 'rejected' && result.reason === 'abort') {
-              this.state = WorkerState.INACTIVE;
-              break;
-            }
-          }
-        }
+
+        failedIterations = 0;
+        errorBackoffMs = 1000;
+
       } catch (err) {
-        this.logger.error(`[${this.workerId}]: Error: ${err}`);
-        await delay(20000);
+        this.logger.error(`[${this.workerId}]: Error in main loop: ${err}. Retrying in ${errorBackoffMs}ms`);
+        failedIterations++;
+
+        if (failedIterations > 10) {
+          this.logger.error(`[${this.workerId}]: Too many failed iterations (${failedIterations}). Pausing worker for ${this.pauseDuration}ms.`);
+          this.pause();
+          failedIterations = 0;
+        }
+
+        await delay(errorBackoffMs);
+        errorBackoffMs = Math.min(errorBackoffMs * 2, maxErrorBackoffMs);
       }
     }
+
+    this.logger.info(`[${this.workerId}]: Worker stopped. Final internal queue size: ${this.internalQueue.getQueueSize()}`);
   }
 }

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -134,7 +134,8 @@ describe('A Worker', () => {
     ddbMock.on(PutItemCommand).resolves(putItemReply);
     ddbMock.on(DescribeTableCommand).resolves(describeTableReply);
     // Test the Worker
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(3);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -144,7 +145,7 @@ describe('A Worker', () => {
   });
 
   // Try Again if messages = 0
-  it('should receive Queue messages, push to database, remove messages from Queue', async () => {
+  it('should receive Queue messages after retry, push to database, remove messages from Queue', async () => {
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
     const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
@@ -160,7 +161,8 @@ describe('A Worker', () => {
     ddbMock.on(PutItemCommand).resolves(putItemReply);
     ddbMock.on(DescribeTableCommand).resolves(describeTableReply);
     // Test the Worker
-    testWorker.setLoopIterations(2);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(5);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -218,7 +220,8 @@ describe('A Worker', () => {
     sqsMock.on(DeleteMessageCommand).resolves(deleteMsgReply);
     ddbMock.on(DescribeTableCommand).rejects(itemReply);
     // Test the Worker
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(3);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -272,7 +275,8 @@ describe('A Worker', () => {
     sqsMock.on(DeleteMessageCommand).resolves(deleteMsgReply);
     ddbMock.on(DescribeTableCommand).resolves(describeTableReply);
     // Test the Worker
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(3);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -308,7 +312,8 @@ describe('A Worker', () => {
     sqsMock.on(DeleteMessageCommand).resolves(deleteMsgReply);
     ddbMock.on(DescribeTableCommand).rejects(itemReply);
     // Test the Worker
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(3);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -344,7 +349,8 @@ describe('A Worker', () => {
     ddbMock.on(PutItemCommand).rejects(itemReply);
     ddbMock.on(DescribeTableCommand).resolves(describeTableReply);
     // Test the Worker
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(3);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -380,7 +386,8 @@ describe('A Worker', () => {
     ddbMock.on(PutItemCommand).rejects(itemReply);
     ddbMock.on(DescribeTableCommand).resolves(describeTableReply);
     // Test the Worker
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(3);
     await testWorker.startAsync();
 
     expect(spyTableExists).toHaveBeenCalled();
@@ -442,13 +449,14 @@ describe('A Worker', () => {
     ).and.callThrough();
 
     const testWorker = new Worker({ logger: Logger });
-    
+
     sqsMock.on(ReceiveMessageCommand).callsFake(() => multipleMessagesReply);
     sqsMock.on(DeleteMessageCommand).resolves(deleteMsgReply);
     ddbMock.on(PutItemCommand).resolves(putItemReply);
     ddbMock.on(DescribeTableCommand).resolves(describeTableReply);
 
-    testWorker.setLoopIterations(1);
+    testWorker.setTestIntervals(100, 200);
+    testWorker.setLoopIterations(2);
     await testWorker.startAsync();
 
     // Verify basic operations
@@ -457,7 +465,7 @@ describe('A Worker', () => {
     expect(spyGetEvent).toHaveBeenCalled();
     expect(spyRemove).toHaveBeenCalled();
 
-    // Verify batch behavior - should be called twice (once per table)
+    // Verify batch behavior - should be called twice (once per table) in first batch
     expect(spyWrite).toHaveBeenCalledTimes(2);
 
     // Verify the first call was for tenant.one table with 2 events


### PR DESCRIPTION
## Summary

- Re-implements the internal memory queue architecture that was previously reverted
- Adds gradual exponential back-off on errors instead of immediate 20-second delay
- Adds pause/resume functionality with auto-resume capability

## Changes

### Internal Queue (`lib/InternalQueue.ts`)
- Memory-based message buffering with configurable batch sizes
- Backpressure mechanism prevents message loss when queue reaches capacity
- Message grouping by table for efficient batch writes
- Retry tracking with max retry limit

### Worker (`lib/Worker.ts`)
- Dual processing loops: separate SQS consumption from database writes
- Gradual exponential back-off: 1s → 2s → 4s → 8s → 16s → 20s (max)
- Public `pause()` and `resume()` methods for manual control
- Auto-resume after configurable pause duration (default: 5 minutes)

### EventDB (`lib/EventDB.ts`)
- New `batchWriteByTable()` method for parallel writes across multiple tables

## Configuration

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `INTERNAL_QUEUE_BATCH_SIZE` | 50 | Messages per batch |
| `INTERNAL_QUEUE_MAX_SIZE` | 1000 | Max queue capacity |
| `SQS_PULL_INTERVAL` | 1000ms | SQS polling interval |
| `DB_PROCESS_INTERVAL` | 2000ms | Database write interval |
| `PAUSE_DURATION` | 300000ms | Auto-resume delay after pause |

## Test plan

- [x] All existing tests pass
- [ ] Manual testing with SQS and DynamoDB
- [ ] Verify backpressure works when DB is slow
- [ ] Verify auto-resume after pause duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)