### PR TITLE
feat: concurrent producer/consumer loops with startup jitter

### DIFF
--- a/lib/Queue.ts
+++ b/lib/Queue.ts
@@ -29,7 +29,8 @@ export default class Queue {
           this.logger.warn(`[${this.instanceId}]: No queue type specified`);
           throw new Error('No queue type specified');
       }
-      this.QueueAdapter = new queueAdapter(this.logger);
+      const skipQueueExistsCheck = process.env.SKIP_QUEUE_EXISTS_CHECK === 'true';
+      this.QueueAdapter = new queueAdapter(this.logger, { skipQueueExistsCheck });
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@eyevinn/player-analytics-shared": "^0.8.0",
+        "@eyevinn/player-analytics-shared": "^0.9.4",
         "@types/node": "^16.6.1",
         "uuid": "^8.3.2",
         "winston": "^3.3.3"
@@ -1503,9 +1503,9 @@
       }
     },
     "node_modules/@eyevinn/player-analytics-shared": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.8.0.tgz",
-      "integrity": "sha512-RgcFtG6JLlwHSKo1t1fvSE1nykFAfm5kQszPzhkEOBdGb04EItajkqca9glVXmyGuHodI1V2hCkD3LbubX5hUw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.9.4.tgz",
+      "integrity": "sha512-NMKazcwYymHrfHgdyMvJLahwBSSPoRDOi8EFlwntsNstl6T/bOaQpMUg5EAJK+14pmAtl9ITuxqFeT4aEvXQMA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.751.0",
@@ -7377,9 +7377,9 @@
       }
     },
     "@eyevinn/player-analytics-shared": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.8.0.tgz",
-      "integrity": "sha512-RgcFtG6JLlwHSKo1t1fvSE1nykFAfm5kQszPzhkEOBdGb04EItajkqca9glVXmyGuHodI1V2hCkD3LbubX5hUw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.9.4.tgz",
+      "integrity": "sha512-NMKazcwYymHrfHgdyMvJLahwBSSPoRDOi8EFlwntsNstl6T/bOaQpMUg5EAJK+14pmAtl9ITuxqFeT4aEvXQMA==",
       "requires": {
         "@aws-sdk/client-dynamodb": "^3.751.0",
         "@aws-sdk/client-sqs": "^3.750.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@eyevinn/player-analytics-shared": "^0.8.0",
+    "@eyevinn/player-analytics-shared": "^0.9.4",
     "@types/node": "^16.6.1",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"


### PR DESCRIPTION
## Summary

- Refactor Worker to use truly concurrent SQS producer and DB consumer loops using `Promise.all`, allowing SQS polling and database writes to happen simultaneously
- Add `SKIP_QUEUE_EXISTS_CHECK` environment variable to skip queue validation on startup
- Add `STARTUP_JITTER_MS` environment variable to spread out worker starts and avoid thundering herd problem
- Update README with configuration documentation for all environment variables

## Test plan

- [x] All existing tests pass
- [ ] Deploy with multiple workers and verify staggered startup in logs
- [ ] Verify SQS polling and DB writes happen concurrently under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)