### PR TITLE
refactor: move table existence check to DB consumer

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -227,7 +227,8 @@ describe('A Worker', () => {
     expect(spyTableExists).toHaveBeenCalled();
     expect(spyWrite).not.toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
-    expect(spyRemove).not.toHaveBeenCalled();
+    // Messages are removed from SQS immediately and requeued internally if table doesn't exist
+    expect(spyRemove).toHaveBeenCalled();
   });
 
   it('should not push item to DB if target table status is not ACTIVE', async () => {
@@ -282,7 +283,8 @@ describe('A Worker', () => {
     expect(spyTableExists).toHaveBeenCalled();
     expect(spyWrite).not.toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
-    expect(spyRemove).not.toHaveBeenCalled();
+    // Messages are removed from SQS immediately and requeued internally if table is not active
+    expect(spyRemove).toHaveBeenCalled();
   });
 
   it('should remove item from queue if it has expired and the target table does not exist', async () => {


### PR DESCRIPTION
## Summary

- Move table existence validation from SQS producer to DB consumer loop for true decoupling
- SQS producer now simply adds messages to the internal queue without any database calls
- Improves throughput by eliminating DB calls from the SQS polling loop

**Before:**
- SQS Producer: fetch → check table exists (DB call) → add to queue → remove from SQS

**After:**
- SQS Producer: fetch → add to queue → remove from SQS (no DB calls)
- DB Consumer: check table exists → write or requeue/discard

If a table doesn't exist:
- Events that haven't expired are requeued in the internal queue for retry
- Expired events are discarded

## Test plan

- [x] All existing tests pass (updated to reflect new behavior)
- [ ] Verify SQS polling is faster without DB calls
- [ ] Verify messages for non-existent tables are properly requeued

🤖 Generated with [Claude Code](https://claude.com/claude-code)