### PR TITLE
feat: add concurrent SQS receives to overcome 10 message limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The workers should start polling the SQS queue for messages and writing them to 
 | `DB_TYPE` | Database type (`DYNAMODB`, `CLICKHOUSE`) | Required |
 | `NUMBER_OF_WORKERS` | Number of worker instances to run | `2` |
 | `SQS_PULL_INTERVAL` | Interval in ms between SQS polling cycles | `1000` |
+| `SQS_CONCURRENT_RECEIVES` | Number of concurrent SQS receive calls per interval (max 10 msgs each) | `5` |
 | `DB_PROCESS_INTERVAL` | Interval in ms between database write cycles | `2000` |
 | `STARTUP_JITTER_MS` | Maximum random startup delay in ms to spread out worker starts | `5000` |
 | `SKIP_QUEUE_EXISTS_CHECK` | Skip queue existence validation on startup (`true`/`false`) | `false` |


### PR DESCRIPTION
## Summary

- Add `SQS_CONCURRENT_RECEIVES` configuration option (default: 5)
- Make multiple parallel SQS receive calls per polling interval
- Overcomes the SQS limit of 10 messages per receive call

**Throughput calculation:**

| Setting | Messages per interval |
|---------|----------------------|
| 1 concurrent receive | 10 messages |
| 5 concurrent receives (default) | 50 messages |
| 10 concurrent receives | 100 messages |

Combined with `SQS_PULL_INTERVAL=100` (10 polls/sec) and default 5 concurrent receives:
- **500 messages/second per worker**

## Test plan

- [x] All existing tests pass
- [ ] Load test with high message volume
- [ ] Verify concurrent receives work correctly with SQS

🤖 Generated with [Claude Code](https://claude.com/claude-code)