### PR TITLE
feat: use batch queue removal and make queue adapter generic

### DIFF
--- a/lib/Queue.ts
+++ b/lib/Queue.ts
@@ -58,6 +58,17 @@ export default class Queue {
     }
   }
 
+  public async removeBatch(messages: Object[]): Promise<Object> {
+    try {
+      await this.getQueueAdapter();
+      const queueResponse = await this.QueueAdapter.removeFromQueueBatch(messages);
+      return queueResponse;
+    } catch (err) {
+      this.logger.error(`[${this.instanceId}]: ${err}`);
+      throw new Error(err);
+    }
+  }
+
   public getEventJSONsFromMessages(messages: any[]): any[] {
     return this.QueueAdapter.getEventJSONsFromMessages(messages);
   }

--- a/lib/Worker.ts
+++ b/lib/Worker.ts
@@ -28,20 +28,20 @@ export class Worker {
   workerId: string;
   tablePrefix: string;
   iterations: number;
-  sqsIterations: number;
+  queueIterations: number;
   maxAge: number;
-  sqsPullInterval: number;
+  queuePullInterval: number;
   dbProcessInterval: number;
   isPaused: boolean;
   pauseDuration: number;
   startupJitterMs: number;
-  sqsConcurrentReceives: number;
+  queueConcurrentReceives: number;
   private pausedAt: number;
 
   constructor(opts: IWorkerOptions) {
     this.logger = opts.logger;
     this.iterations = -1;
-    this.sqsIterations = -1;
+    this.queueIterations = -1;
     this.tablePrefix = TABLE_PREFIX;
     this.workerId = uuidv4();
     this.state = WorkerState.IDLE;
@@ -49,13 +49,24 @@ export class Worker {
     this.db = new EventDB(opts.logger, this.workerId);
     this.internalQueue = new InternalQueue(opts.logger, this.workerId);
     this.maxAge = process.env.MAX_AGE ? parseInt(process.env.MAX_AGE) : 60000;
-    this.sqsPullInterval = process.env.SQS_PULL_INTERVAL ? parseInt(process.env.SQS_PULL_INTERVAL) : 1000;
+    this.queuePullInterval = this.getEnvWithDeprecation('QUEUE_PULL_INTERVAL', 'SQS_PULL_INTERVAL', 1000);
     this.dbProcessInterval = process.env.DB_PROCESS_INTERVAL ? parseInt(process.env.DB_PROCESS_INTERVAL) : 2000;
     this.isPaused = false;
     this.pausedAt = 0;
     this.pauseDuration = process.env.PAUSE_DURATION ? parseInt(process.env.PAUSE_DURATION) : 300000; // 5 minutes default
     this.startupJitterMs = process.env.STARTUP_JITTER_MS ? parseInt(process.env.STARTUP_JITTER_MS) : 5000; // 5 seconds default
-    this.sqsConcurrentReceives = process.env.SQS_CONCURRENT_RECEIVES ? parseInt(process.env.SQS_CONCURRENT_RECEIVES) : 5;
+    this.queueConcurrentReceives = this.getEnvWithDeprecation('QUEUE_CONCURRENT_RECEIVES', 'SQS_CONCURRENT_RECEIVES', 5);
+  }
+
+  private getEnvWithDeprecation(newName: string, deprecatedName: string, defaultValue: number): number {
+    if (process.env[newName]) {
+      return parseInt(process.env[newName] as string);
+    }
+    if (process.env[deprecatedName]) {
+      this.logger.warn(`[${this.workerId}]: Environment variable ${deprecatedName} is deprecated, use ${newName} instead`);
+      return parseInt(process.env[deprecatedName] as string);
+    }
+    return defaultValue;
   }
 
   resume() {
@@ -78,43 +89,34 @@ export class Worker {
   setLoopIterations(iterations: number) {
     this.logger.warn(`[${this.workerId}]: Setting worker iterations to: ${iterations}`);
     this.iterations = iterations;
-    this.sqsIterations = iterations;
+    this.queueIterations = iterations;
   }
 
   // For unit tests only - set faster intervals for testing
-  setTestIntervals(sqsInterval: number = 100, dbInterval: number = 200) {
-    this.sqsPullInterval = sqsInterval;
+  setTestIntervals(queueInterval: number = 100, dbInterval: number = 200) {
+    this.queuePullInterval = queueInterval;
     this.dbProcessInterval = dbInterval;
-    this.sqsConcurrentReceives = 1; // Use single receive for predictable test behavior
-    this.logger.warn(`[${this.workerId}]: Test mode - SQS interval: ${sqsInterval}ms, DB interval: ${dbInterval}ms`);
+    this.queueConcurrentReceives = 1; // Use single receive for predictable test behavior
+    this.logger.warn(`[${this.workerId}]: Test mode - Queue interval: ${queueInterval}ms, DB interval: ${dbInterval}ms`);
   }
 
-  private async removeFromQueue(message: any) {
+  private async processQueueMessages() {
     try {
-      await this.queue.remove(message);
-      this.logger.debug(`[${this.workerId}]: Removed message from Queue!`);
-    } catch (err) {
-      this.logger.error(`[${this.workerId}]: Error Removing item from Queue!`, err);
-    }
-  }
-
-  private async processSQSMessages() {
-    try {
-      // Check if internal queue has capacity before consuming from SQS
+      // Check if internal queue has capacity before consuming from queue
       if (!this.internalQueue.hasCapacity(1)) {
-        this.logger.debug(`[${this.workerId}]: Internal queue is full (${this.internalQueue.getQueueSize()}/${this.internalQueue.maxQueueSize}). Skipping SQS consumption.`);
+        this.logger.debug(`[${this.workerId}]: Internal queue is full (${this.internalQueue.getQueueSize()}/${this.internalQueue.maxQueueSize}). Skipping queue consumption.`);
         return;
       }
 
-      // Make concurrent receive calls to overcome SQS 10 message limit
+      // Make concurrent receive calls to improve throughput
       const receiveStartTime = Date.now();
-      const receivePromises = Array(this.sqsConcurrentReceives)
+      const receivePromises = Array(this.queueConcurrentReceives)
         .fill(null)
         .map((_, idx) => {
           const startTime = Date.now();
-          this.logger.debug(`[${this.workerId}]: SQS receive #${idx + 1} starting`);
+          this.logger.debug(`[${this.workerId}]: Queue receive #${idx + 1} starting`);
           return this.queue.receive().then((result) => {
-            this.logger.debug(`[${this.workerId}]: SQS receive #${idx + 1} completed in ${Date.now() - startTime}ms`);
+            this.logger.debug(`[${this.workerId}]: Queue receive #${idx + 1} completed in ${Date.now() - startTime}ms`);
             return result;
           });
         });
@@ -126,11 +128,11 @@ export class Worker {
         .flat();
 
       if (collectedMessages.length === 0) {
-        this.logger.debug(`[${this.workerId}]: No messages received from SQS (${receiveDuration}ms)`);
+        this.logger.debug(`[${this.workerId}]: No messages received from queue (${receiveDuration}ms)`);
         return;
       }
 
-      this.logger.debug(`[${this.workerId}]: Retrieved ${collectedMessages.length} messages from SQS in ${receiveDuration}ms (${this.sqsConcurrentReceives} concurrent receives, ${(collectedMessages.length / (receiveDuration / 1000)).toFixed(1)} msgs/sec)`);
+      this.logger.debug(`[${this.workerId}]: Retrieved ${collectedMessages.length} messages from queue in ${receiveDuration}ms (${this.queueConcurrentReceives} concurrent receives, ${(collectedMessages.length / (receiveDuration / 1000)).toFixed(1)} msgs/sec)`);
 
       const allEvents: any[] = this.queue.getEventJSONsFromMessages(collectedMessages);
       const messagesToRemove: any[] = [];
@@ -158,22 +160,25 @@ export class Worker {
         }
       }
 
-      // Remove messages from SQS in parallel
+      // Remove messages from queue using batch API
       if (messagesToRemove.length > 0) {
         const removeStartTime = Date.now();
-        this.logger.debug(`[${this.workerId}]: Removing ${messagesToRemove.length} messages from SQS`);
-        await Promise.all(messagesToRemove.map(msg => this.removeFromQueue(msg)));
+        this.logger.debug(`[${this.workerId}]: Removing ${messagesToRemove.length} messages from queue`);
+        const result: any = await this.queue.removeBatch(messagesToRemove);
         const removeDuration = Date.now() - removeStartTime;
-        this.logger.debug(`[${this.workerId}]: Removed ${messagesToRemove.length} messages from SQS in ${removeDuration}ms`);
+        if (result.failed && result.failed.length > 0) {
+          this.logger.error(`[${this.workerId}]: Failed to remove ${result.failed.length} messages from queue`);
+        }
+        this.logger.debug(`[${this.workerId}]: Removed ${result.successful?.length || 0} messages from queue in ${removeDuration}ms`);
       }
 
       if (skippedCount > 0) {
-        this.logger.warn(`[${this.workerId}]: Could not process ${skippedCount} messages due to internal queue capacity. Messages remain in SQS for retry.`);
+        this.logger.warn(`[${this.workerId}]: Could not process ${skippedCount} messages due to internal queue capacity. Messages remain in queue for retry.`);
       }
 
-      this.logger.debug(`[${this.workerId}]: Added ${messagesToRemove.length} messages to internal queue and removed from SQS. Queue size: ${this.internalQueue.getQueueSize()}`);
+      this.logger.debug(`[${this.workerId}]: Added ${messagesToRemove.length} messages to internal queue and removed from queue. Queue size: ${this.internalQueue.getQueueSize()}`);
     } catch (err) {
-      this.logger.error(`[${this.workerId}]: Error processing SQS messages: ${err}`);
+      this.logger.error(`[${this.workerId}]: Error processing queue messages: ${err}`);
     }
   }
 
@@ -252,8 +257,8 @@ export class Worker {
     }
   }
 
-  private async runSQSProducerLoop(): Promise<void> {
-    this.logger.info(`[${this.workerId}]: SQS producer loop started - interval: ${this.sqsPullInterval}ms`);
+  private async runQueueProducerLoop(): Promise<void> {
+    this.logger.info(`[${this.workerId}]: Queue producer loop started - interval: ${this.queuePullInterval}ms`);
 
     let failedIterations = 0;
     let errorBackoffMs = 1000;
@@ -266,22 +271,22 @@ export class Worker {
       }
 
       // For unit tests - decrement iterations in producer loop
-      if (this.sqsIterations > 0) this.sqsIterations--;
-      if (this.sqsIterations === 0) break;
+      if (this.queueIterations > 0) this.queueIterations--;
+      if (this.queueIterations === 0) break;
 
       try {
-        await this.processSQSMessages();
+        await this.processQueueMessages();
 
         failedIterations = 0;
         errorBackoffMs = 1000;
 
-        await delay(this.sqsPullInterval);
+        await delay(this.queuePullInterval);
       } catch (err) {
-        this.logger.error(`[${this.workerId}]: Error in SQS producer loop: ${err}. Retrying in ${errorBackoffMs}ms`);
+        this.logger.error(`[${this.workerId}]: Error in queue producer loop: ${err}. Retrying in ${errorBackoffMs}ms`);
         failedIterations++;
 
         if (failedIterations > 10) {
-          this.logger.error(`[${this.workerId}]: Too many SQS failures (${failedIterations}). Pausing worker.`);
+          this.logger.error(`[${this.workerId}]: Too many queue failures (${failedIterations}). Pausing worker.`);
           this.pause();
           failedIterations = 0;
         }
@@ -291,7 +296,7 @@ export class Worker {
       }
     }
 
-    this.logger.info(`[${this.workerId}]: SQS producer loop stopped`);
+    this.logger.info(`[${this.workerId}]: Queue producer loop stopped`);
   }
 
   private async runDBConsumerLoop(): Promise<void> {
@@ -330,7 +335,7 @@ export class Worker {
             this.logger.info(`[${this.workerId}]: Internal queue stats - Size: ${stats.size}/${this.internalQueue.maxQueueSize}, Available capacity: ${capacity}, Oldest message: ${stats.oldestMessage}ms`);
           }
           if (capacity === 0) {
-            this.logger.warn(`[${this.workerId}]: Internal queue is at capacity! SQS consumption is paused.`);
+            this.logger.warn(`[${this.workerId}]: Internal queue is at capacity! Queue consumption is paused.`);
           }
           lastStatsLog = now;
         }
@@ -367,11 +372,11 @@ export class Worker {
       await delay(jitter);
     }
 
-    this.logger.info(`[${this.workerId}]: Worker starting with concurrent producer/consumer loops - SQS interval: ${this.sqsPullInterval}ms, DB interval: ${this.dbProcessInterval}ms`);
+    this.logger.info(`[${this.workerId}]: Worker starting with concurrent producer/consumer loops - Queue interval: ${this.queuePullInterval}ms, DB interval: ${this.dbProcessInterval}ms`);
 
     // Run both loops concurrently - they operate independently
     await Promise.all([
-      this.runSQSProducerLoop(),
+      this.runQueueProducerLoop(),
       this.runDBConsumerLoop()
     ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@eyevinn/player-analytics-shared": "^0.9.4",
+        "@eyevinn/player-analytics-shared": "^0.10.0",
         "@types/node": "^16.6.1",
         "uuid": "^8.3.2",
         "winston": "^3.3.3"
@@ -1503,9 +1503,9 @@
       }
     },
     "node_modules/@eyevinn/player-analytics-shared": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.9.4.tgz",
-      "integrity": "sha512-NMKazcwYymHrfHgdyMvJLahwBSSPoRDOi8EFlwntsNstl6T/bOaQpMUg5EAJK+14pmAtl9ITuxqFeT4aEvXQMA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.10.0.tgz",
+      "integrity": "sha512-MSXcZS092Ie/PfpOUNvI6ytKrp7IoDTbZFn1wVNb/CtVoi+hGrfBovHKc6/eXqHgwPtzbLJzeZuKkZ6zpbiZag==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.751.0",
@@ -7377,9 +7377,9 @@
       }
     },
     "@eyevinn/player-analytics-shared": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.9.4.tgz",
-      "integrity": "sha512-NMKazcwYymHrfHgdyMvJLahwBSSPoRDOi8EFlwntsNstl6T/bOaQpMUg5EAJK+14pmAtl9ITuxqFeT4aEvXQMA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eyevinn/player-analytics-shared/-/player-analytics-shared-0.10.0.tgz",
+      "integrity": "sha512-MSXcZS092Ie/PfpOUNvI6ytKrp7IoDTbZFn1wVNb/CtVoi+hGrfBovHKc6/eXqHgwPtzbLJzeZuKkZ6zpbiZag==",
       "requires": {
         "@aws-sdk/client-dynamodb": "^3.751.0",
         "@aws-sdk/client-sqs": "^3.750.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@eyevinn/player-analytics-shared": "^0.9.4",
+    "@eyevinn/player-analytics-shared": "^0.10.0",
     "@types/node": "^16.6.1",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -121,7 +121,7 @@ describe('A Worker', () => {
   it('should receive Queue messages, push to database, remove messages from Queue', async () => {
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -141,14 +141,14 @@ describe('A Worker', () => {
     expect(spyTableExists).toHaveBeenCalled();
     expect(spyWrite).toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
   });
 
   // Try Again if messages = 0
   it('should receive Queue messages after retry, push to database, remove messages from Queue', async () => {
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -168,7 +168,7 @@ describe('A Worker', () => {
     expect(spyTableExists).toHaveBeenCalled();
     expect(spyWrite).toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
   });
 
   it('should not push item to DB if target table does not exist', async () => {
@@ -209,7 +209,7 @@ describe('A Worker', () => {
     };
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -228,7 +228,7 @@ describe('A Worker', () => {
     expect(spyWrite).not.toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
     // Messages are removed from SQS immediately and requeued internally if table doesn't exist
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
   });
 
   it('should not push item to DB if target table status is not ACTIVE', async () => {
@@ -265,7 +265,7 @@ describe('A Worker', () => {
     };
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -284,7 +284,7 @@ describe('A Worker', () => {
     expect(spyWrite).not.toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
     // Messages are removed from SQS immediately and requeued internally if table is not active
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
   });
 
   it('should remove item from queue if it has expired and the target table does not exist', async () => {
@@ -303,7 +303,7 @@ describe('A Worker', () => {
     };
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -321,13 +321,13 @@ describe('A Worker', () => {
     expect(spyTableExists).toHaveBeenCalled();
     expect(spyWrite).not.toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
   });
 
   it('should remove messages from SQS immediately after adding to internal queue, even if DB write fails', async () => {
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -360,13 +360,13 @@ describe('A Worker', () => {
     expect(spyWrite).toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
     // Messages are removed from SQS immediately after adding to internal queue
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
   });
 
   it('should requeue failed messages in internal queue when DB error occurs', async () => {
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -399,7 +399,7 @@ describe('A Worker', () => {
     expect(spyWrite).toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
     // Messages are removed from SQS immediately, failed DB writes are requeued in internal queue
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
     expect(testWorker.state).toEqual(WorkerState.INACTIVE);
   });
 
@@ -448,7 +448,7 @@ describe('A Worker', () => {
 
     const spyTableExists = spyOn(EventDB.prototype, 'TableExists').and.callThrough();
     const spyWrite = spyOn(EventDB.prototype, 'writeMultiple').and.callThrough();
-    const spyRemove = spyOn(Queue.prototype, 'remove').and.callThrough();
+    const spyRemoveBatch = spyOn(Queue.prototype, 'removeBatch').and.callThrough();
     const spyGetEvent = spyOn(
       Queue.prototype,
       'getEventJSONsFromMessages'
@@ -469,7 +469,7 @@ describe('A Worker', () => {
     expect(spyTableExists).toHaveBeenCalled();
     expect(spyWrite).toHaveBeenCalled();
     expect(spyGetEvent).toHaveBeenCalled();
-    expect(spyRemove).toHaveBeenCalled();
+    expect(spyRemoveBatch).toHaveBeenCalled();
 
     // Verify batch behavior - should be called twice (once per table) in first batch
     expect(spyWrite).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary
- Add `removeBatch()` method to Queue class leveraging the batch removal capability in the queue adapter
- Update Worker to use batch removal instead of parallel individual removals for improved throughput
- Rename all internal SQS-specific methods/properties to generic names (e.g., `processQueueMessages`, `queuePullInterval`)
- Update all logging messages to use generic "queue" terminology
- Add new environment variables `QUEUE_PULL_INTERVAL` and `QUEUE_CONCURRENT_RECEIVES` with backward compatibility for deprecated `SQS_*` variants

## Test plan
- [x] All existing tests pass
- [x] Build completes successfully
- [ ] Verify batch removal works correctly in staging environment
- [ ] Verify deprecation warnings are logged when using old environment variable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)